### PR TITLE
Add childNodes.length property

### DIFF
--- a/lib/simple-dom/document/node.js
+++ b/lib/simple-dom/document/node.js
@@ -131,4 +131,18 @@ ChildNodes.prototype.item = function(index) {
   return child;
 };
 
+Object.defineProperty(ChildNodes.prototype, 'length', {
+    get: function() {
+	var child = this.node.firstChild;
+	var length = 0;
+	
+	while (child) {
+	    length ++;
+	    child = child.nextSibling;
+	}
+	
+	return length;
+    }
+});
+
 export default Node;

--- a/test/element-test.js
+++ b/test/element-test.js
@@ -66,6 +66,32 @@ QUnit.test("child nodes can be access via item()", function(assert) {
   assert.strictEqual(parent.childNodes.item(1), null);
 });
 
+// http://www.w3.org/TR/2004/REC-DOM-Level-3-Core-20040407/core.html#ID-203510337
+QUnit.test("childNodes has correct length property", function(assert) {
+
+    var document = new Document();
+    var fragment = document.createDocumentFragment();
+    var childDiv = document.createElement('div');
+
+    // document.body has no children yet
+    assert.equal(document.body.childNodes.length, 0, "empty node's childNodes.length is 0");
+
+    document.body.appendChild(childDiv);
+
+    // now it has one child
+    assert.equal(document.body.childNodes.length, 1, "when node has one child, its childNodes.length is 1");
+
+    for (var i = 0; i < 4; i++) {
+	fragment.appendChild( document.createElement('div') );
+    }
+
+    document.body.appendChild(fragment);
+    
+    // now it has 1 + 4 new children = 5
+    assert.equal(document.body.childNodes.length, 5, "after appending document fragment, childNodes.length is still correct");
+    
+});
+
 QUnit.test("insertBefore can insert before the last child node", function(assert) {
   var document = new Document();
 


### PR DESCRIPTION
In the current master, Node.childNodes has no length property. That's not compliant with DOM Core (http://www.w3.org/TR/2004/REC-DOM-Level-3-Core-20040407/core.html#ID-203510337) and can be a pain if writing code to check for element children. For example, this simple code won't work:
```javascript
var hasChildren = !!someNode.childNodes.length
```

Using Object.defineGetter seems the simplest and most elegant solution here. It's supported by Chrome, FF, Opera 9.5, Safari 3 and IE 9: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/get

Cheers,
Dawid