### PR TITLE
Ensure Node#insertBefore removes node from parentNode

### DIFF
--- a/lib/simple-dom/document/node.js
+++ b/lib/simple-dom/document/node.js
@@ -90,14 +90,16 @@ Node.prototype.insertBefore = function(node, refNode) {
     return;
   }
 
+  if (node.parentNode) { node.parentNode.removeChild(node); }
+
   node.parentNode = this;
 
   var previousSibling = refNode.previousSibling;
   if (previousSibling) {
     previousSibling.nextSibling = node;
     node.previousSibling = previousSibling;
-  }else{
-    node.previousSibling = null
+  } else {
+    node.previousSibling = null;
   }
 
   refNode.previousSibling = node;

--- a/test/element-test.js
+++ b/test/element-test.js
@@ -85,6 +85,27 @@ QUnit.test("insertBefore can insert before the last child node", function(assert
   assert.strictEqual(parent.childNodes.item(1), child3);
 });
 
+QUnit.test("insertBefore removes the node from its parent before inserting", function(assert) {
+  var document = new Document();
+  var body = document.body;
+
+  var parent = document.createElement('div');
+  var child =  document.createElement('span');
+  parent.appendChild(child);
+  body.appendChild(parent);
+
+  assert.strictEqual(parent.firstChild, child, 'precond - parent.firstChild === child');
+  assert.strictEqual(parent.lastChild, child, 'precond - parent.lastChild === child');
+  assert.strictEqual(body.firstChild, parent, 'precond - body.firstChild === parent');
+
+  document.body.insertBefore(child, body.firstChild);
+
+  assert.strictEqual(body.firstChild, child, 'body firstChild replaced with child');
+  assert.strictEqual(child.parentNode, body, 'child parentNode updated to body');
+  assert.strictEqual(parent.firstChild, null, 'child removed from parent (firstChild)');
+  assert.strictEqual(parent.lastChild, null, 'child removed from parent (lastChild)');
+});
+
 QUnit.test("cloneNode(true) recursively clones nodes", function(assert) {
   var document = new Document();
   var parent = document.createElement('div');


### PR DESCRIPTION
If th child node is not removed, HTML serialization can encounter infinite recursion, e.g.:
```javascript
var body = document.body;
var parent = document.createElement('div');
var child = document.createElement('span')
parent.appendChild(child);
body.appendChild(parent);

// move child from parent to be the first child of body
body.insertBefore(child, body.firstChild);

new Serializer(voidMap).serialize(body); // -> infinite recursion
```