### PR TITLE
Add stricter nodeType type annotations

### DIFF
--- a/src/simple-dom/document.ts
+++ b/src/simple-dom/document.ts
@@ -1,11 +1,12 @@
 import Comment from './document/comment';
 import DocumentFragment from './document/document-fragment';
 import Element from './document/element';
-import Node from './document/node';
+import Node, { NodeType } from './document/node';
 import RawHTMLSection from './document/raw-html-section';
 import Text from './document/text';
 
 export default class Document extends Node {
+  public nodeType: NodeType.DOCUMENT_NODE;
   public documentElement: Element;
   public head: Element;
   public body: Element;

--- a/src/simple-dom/document/comment.ts
+++ b/src/simple-dom/document/comment.ts
@@ -1,6 +1,7 @@
 import Node, { NodeType } from './node';
 
 export default class Comment extends Node {
+  public nodeType: NodeType.COMMENT_NODE;
   public nodeValue: string;
 
   constructor(text: string) {

--- a/src/simple-dom/document/document-fragment.ts
+++ b/src/simple-dom/document/document-fragment.ts
@@ -1,6 +1,8 @@
 import Node, { NodeType } from './node';
 
 export default class DocumentFragment extends Node {
+  public nodeType: NodeType.DOCUMENT_FRAGMENT_NODE;
+
   constructor() {
     super(NodeType.DOCUMENT_FRAGMENT_NODE, '#document-fragment', null);
   }

--- a/src/simple-dom/document/text.ts
+++ b/src/simple-dom/document/text.ts
@@ -1,6 +1,7 @@
 import Node, { NodeType } from './node';
 
 export default class Text extends Node {
+  public nodeType: NodeType.TEXT_NODE;
   public nodeValue: string;
 
   constructor(text: string) {


### PR DESCRIPTION
This commit makes all of the node subclasses in simple-dom consistent with Element, which includes a more-refined nodeType property type annotation. By making these types enum values, it's easier for external systems to better type check passed values.