### PR TITLE
Add interface checks for lib.dom.d.ts

### DIFF
--- a/check-types/index.ts
+++ b/check-types/index.ts
@@ -1,0 +1,33 @@
+import { SimpleNode, SimpleDocument, SimpleElement, SimpleText, SimpleComment, SimpleDocumentFragment, SerializableNode, SerializableElement } from '@simple-dom/interface';
+
+export class CheckSimple {
+  createHTMLDocument(): SimpleDocument {
+    return document.implementation.createHTMLDocument('foo') as SimpleDocument;
+  }
+
+  createElement(tagName: string): SimpleElement {
+    return document.createElement(tagName) as SimpleElement;
+  }
+
+  createText(text: string): SimpleText {
+    return document.createTextNode(text) as SimpleText;
+  }
+
+  createComment(text: string): SimpleComment {
+    return document.createComment(text) as SimpleComment;
+  }
+
+  createDocumentFragment(text: string): SimpleDocumentFragment {
+    return document.createDocumentFragment() as SimpleDocumentFragment;
+  }
+}
+
+export class CheckSerializable {
+  createHTMLDocument(): SerializableNode {
+    return document.implementation.createHTMLDocument('foo');
+  }
+
+  createElement(tagName: string): SerializableElement {
+    return document.createElement(tagName);
+  }
+}

--- a/check-types/tsconfig.json
+++ b/check-types/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "noEmit": true,
+    "moduleResolution": "node",
+    "module": "es2015",
+    "target": "es2017",
+    "declaration": true
+  },
+  "files": [
+    "index.ts"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -5,9 +5,10 @@
     "build": "ember build",
     "lint": "tslint -p tsconfig.json",
     "prepare": "ember build --environment=production",
-    "test": "yarn run test:browser && yarn run test:node",
+    "test": "yarn run test:browser && yarn run test:node && yarn run test:types",
     "test:browser": "ember test",
-    "test:node": "nyc --check-coverage -- qunit packages/@simple-dom/*/dist/test/commonjs/index.js packages/simple-dom/dist/test/commonjs/index.js"
+    "test:node": "nyc --check-coverage -- qunit packages/@simple-dom/*/dist/test/commonjs/index.js packages/simple-dom/dist/test/commonjs/index.js",
+    "test:types": "tsc -p check-types/tsconfig.json"
   },
   "devDependencies": {
     "@types/qunit": "^2.0.31",

--- a/packages/@simple-dom/document/src/document.ts
+++ b/packages/@simple-dom/document/src/document.ts
@@ -6,7 +6,8 @@ import {
 import SimpleNodeImpl from './node';
 
 export function createHTMLDocument(): SimpleDocument {
-  const document = new SimpleNodeImpl(null, NodeType.DOCUMENT_NODE, '#document', null, Namespace.HTML);
+  // dom.d.ts types ownerDocument as Document but for a document ownerDocument is null
+  const document = new SimpleNodeImpl(null as any, NodeType.DOCUMENT_NODE, '#document', null, Namespace.HTML);
   const doctype = new SimpleNodeImpl(document, NodeType.DOCUMENT_TYPE_NODE, 'html', null, Namespace.HTML);
   const html = new SimpleNodeImpl(document, NodeType.ELEMENT_NODE, 'HTML', null, Namespace.HTML);
   const head = new SimpleNodeImpl(document, NodeType.ELEMENT_NODE, 'HEAD', null, Namespace.HTML);

--- a/packages/@simple-dom/document/src/node.ts
+++ b/packages/@simple-dom/document/src/node.ts
@@ -32,12 +32,11 @@ import {
   parseQualifiedName,
 } from './qualified-name';
 
-export type SimpleElementImpl = SimpleNodeImpl<NodeType.ELEMENT_NODE, SimpleDocument, null, ElementNamespace>;
-export type SimpleDocumentImpl = SimpleNodeImpl<NodeType.DOCUMENT_NODE, null, null, Namespace.HTML>;
+export type SimpleElementImpl = SimpleNodeImpl<NodeType.ELEMENT_NODE, null, ElementNamespace>;
+export type SimpleDocumentImpl = SimpleNodeImpl<NodeType.DOCUMENT_NODE, null, Namespace.HTML>;
 
 export default class SimpleNodeImpl<
   T extends NodeType,
-  O extends SimpleDocument | null,
   V extends string | null,
   N extends ElementNamespace | undefined
 > {
@@ -55,7 +54,7 @@ export default class SimpleNodeImpl<
   public _childNodes: ChildNodes | undefined = undefined;
 
   constructor(
-    public readonly ownerDocument: O,
+    public readonly ownerDocument: SimpleDocument,
     public readonly nodeType: T,
     public readonly nodeName: string,
     public nodeValue: V,

--- a/packages/@simple-dom/interface/index.d.ts
+++ b/packages/@simple-dom/interface/index.d.ts
@@ -47,7 +47,7 @@ export type SimpleNode =
   SimpleDocumentFragment;
 
 export interface SimpleNodeBase {
-  readonly ownerDocument: SimpleDocument | null;
+  readonly ownerDocument: SimpleDocument;
   readonly nodeType: NodeType;
   readonly nodeName: string;
 
@@ -89,7 +89,6 @@ export interface SimpleAttrs {
 }
 
 export interface SimpleElement extends SimpleNodeBase {
-  readonly ownerDocument: SimpleDocument;
   readonly nodeType: NodeType.ELEMENT_NODE;
   readonly nodeValue: null;
 
@@ -110,19 +109,16 @@ export interface SimpleElement extends SimpleNodeBase {
 }
 
 export interface SimpleDocumentType extends SimpleNodeBase {
-  readonly ownerDocument: SimpleDocument;
   readonly nodeType: NodeType.DOCUMENT_TYPE_NODE;
   readonly nodeValue: null;
 }
 
 export interface SimpleDocumentFragment extends SimpleNodeBase {
-  readonly ownerDocument: SimpleDocument;
   readonly nodeType: NodeType.DOCUMENT_FRAGMENT_NODE;
   readonly nodeValue: null;
 }
 
 export interface SimpleDocument extends SimpleNodeBase {
-  readonly ownerDocument: null;
   readonly nodeType: NodeType.DOCUMENT_NODE;
   readonly nodeValue: null;
 
@@ -146,19 +142,16 @@ export interface SimpleDocument extends SimpleNodeBase {
 }
 
 export interface SimpleRawHTMLSection extends SimpleNodeBase {
-  readonly ownerDocument: SimpleDocument;
   readonly nodeType: NodeType.RAW_NODE;
   readonly nodeValue: string;
 }
 
 export interface SimpleText extends SimpleNodeBase {
-  readonly ownerDocument: SimpleDocument;
   readonly nodeType: NodeType.TEXT_NODE;
   readonly nodeValue: string;
 }
 
 export interface SimpleComment extends SimpleNodeBase {
-  readonly ownerDocument: SimpleDocument;
   readonly nodeType: NodeType.COMMENT_NODE;
   readonly nodeValue: string;
 }
@@ -196,6 +189,6 @@ export interface SerializableAttr {
 }
 
 export interface SerializableElement extends SerializableNode {
-  readonly namespaceURI: string;
+  readonly namespaceURI: string | null;
   readonly attributes: SerializableAttrs;
 }


### PR DESCRIPTION
Check that a `lib.dom.d.ts` Document can be cast as SimpleDocument and that it is implicitly a SerializableNode