### PR TITLE
nodeValue property on comment and text nodes should be mutable

### DIFF
--- a/packages/@simple-dom/document/test/node-test.ts
+++ b/packages/@simple-dom/document/test/node-test.ts
@@ -29,4 +29,18 @@ moduleWithDocument('Node', (helper) => {
     assert.strictEqual(body.lastChild, div, 'parents last child is set');
   });
 
+  QUnit.test('nodeValue is mutable', (assert) => {
+    const doc = helper.document;
+    const text = doc.createTextNode('hello world');
+    const comment = doc.createComment('goodbye cruel world');
+
+    assert.strictEqual(text.nodeValue, 'hello world', 'precond - node value is set');
+    assert.strictEqual(comment.nodeValue, 'goodbye cruel world', 'precond - node value is set');
+
+    text.nodeValue = text.nodeValue.toUpperCase();
+    comment.nodeValue = comment.nodeValue.toUpperCase();
+
+    assert.strictEqual(text.nodeValue, 'HELLO WORLD');
+    assert.strictEqual(comment.nodeValue, 'GOODBYE CRUEL WORLD', 'precond - node value is set');
+  });
 });

--- a/packages/@simple-dom/interface/index.d.ts
+++ b/packages/@simple-dom/interface/index.d.ts
@@ -148,12 +148,12 @@ export interface SimpleRawHTMLSection extends SimpleNodeBase {
 
 export interface SimpleText extends SimpleNodeBase {
   readonly nodeType: NodeType.TEXT_NODE;
-  readonly nodeValue: string;
+  nodeValue: string;
 }
 
 export interface SimpleComment extends SimpleNodeBase {
   readonly nodeType: NodeType.COMMENT_NODE;
-  readonly nodeValue: string;
+  nodeValue: string;
 }
 
 /**


### PR DESCRIPTION
I think this was just an oversight. The DOM API specifies that `nodeValue` should be mutable, but we had it annotated as `readonly`. Glimmer VM relies on setting this property in the `DynamicTextContent` opcode.